### PR TITLE
Only run release on trunk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,8 @@ jobs:
 
 workflows:
   node-tests:
+    unless:
+      equal: ['trunk', << pipeline.git.branch >>]
     jobs:
       - node/test
   release:


### PR DESCRIPTION
We don't run the tests in the trunk, since they're already run during release