### PR TITLE
Fixed orange span shown by default and replaced with v-alert

### DIFF
--- a/src/components/BadMessage.vue
+++ b/src/components/BadMessage.vue
@@ -1,5 +1,13 @@
 <template>
-  <span> {{message}} </span>
+  <v-alert
+      dense
+      outlined
+      dismissible
+      light
+      :value="enabled"
+      :type="messageType">
+    {{message}}
+  </v-alert>  
 </template>
 <script>
 export default {
@@ -7,16 +15,14 @@ export default {
   props: {
     message: {
       type: String
+    },
+    messageType: {
+      type: String
+    },
+    enabled: {
+      type: Boolean
     }
-  }
-};
+  },
+}
 </script>
-<style scoped lang="scss">
-    span{
-        font-size: larger;
-        padding: 5px;
-        background-color: white;
-        border: 1px solid orange;
-        border-radius: 5px;
-    }
-</style>
+<style scoped></style>

--- a/src/components/BookingForm.vue
+++ b/src/components/BookingForm.vue
@@ -57,7 +57,11 @@
         </v-snackbar>
       </v-col>
     </v-row>
-    <bad-message :message="feedback"></bad-message>
+    <bad-message
+        :message="feedback"
+        :messageType="messageType"
+        :enabled="isFeedbackShownOnBooking">
+    </bad-message>
   </v-container>
 </template>
 
@@ -77,10 +81,12 @@ export default {
       bookingDate: this.tomorrow(),
       emailAddress: "",
       feedback: "",
+      messageType: "",
       offices: [],
       selectedOffice: null,
       availabilities: null,
-      isWarningShownOnBooking: false
+      isWarningShownOnBooking: false,
+      isFeedbackShownOnBooking: false
     };
   },
   async mounted() {
@@ -119,18 +125,27 @@ export default {
     officeChange(){
       this.fetchAvailabilities();
     },
+    displayConfirmationMessage(){
+      this.messageType = "success";
+      this.feedback = "Please check your emails for your booking confirmation";
+    },
+    displayWarningMessage(e){
+      this.messageType = "warning"
+      this.feedback = `Something went wrong with the booking: ${e.message}`;
+    },
     async submitBooking() {
-      this.isWarningShownOnBooking = true;
+      this.isWarningShownOnBooking = true;  
+      this.isFeedbackShownOnBooking = true;
       try{
         await this.$store.dispatch("book", {
           office: { id: this.selectedOffice.id },
           date: this.bookingDate,
           user: { email: this.emailAddress }
         });
-        this.feedback = "Please check your emails for your booking confirmation";
+        this.displayConfirmationMessage()
       }
       catch(e){
-        this.feedback = `Something went wrong with the booking: ${e.message}`      
+        this.displayWarningMessage(e)
       }
       this.fetchAvailabilities();
     },    

--- a/src/components/BookingForm.vue
+++ b/src/components/BookingForm.vue
@@ -58,9 +58,9 @@
       </v-col>
     </v-row>
     <bad-message
-        :message="feedback"
+        :message="bookingResultMessage"
         :messageType="messageType"
-        :enabled="isFeedbackShownOnBooking">
+        :enabled="isMessageShownOnBooking">
     </bad-message>
   </v-container>
 </template>
@@ -80,13 +80,13 @@ export default {
     return {
       bookingDate: this.tomorrow(),
       emailAddress: "",
-      feedback: "",
+      bookingResultMessage: "",
       messageType: "",
       offices: [],
       selectedOffice: null,
       availabilities: null,
       isWarningShownOnBooking: false,
-      isFeedbackShownOnBooking: false
+      isMessageShownOnBooking: false
     };
   },
   async mounted() {
@@ -127,15 +127,15 @@ export default {
     },
     displayConfirmationMessage(){
       this.messageType = "success";
-      this.feedback = "Please check your emails for your booking confirmation";
+      this.bookingResultMessage = "Please check your emails for your booking confirmation";
     },
     displayWarningMessage(e){
       this.messageType = "warning"
-      this.feedback = `Something went wrong with the booking: ${e.message}`;
+      this.bookingResultMessage = `Something went wrong with the booking: ${e.message}`;
     },
     async submitBooking() {
       this.isWarningShownOnBooking = true;  
-      this.isFeedbackShownOnBooking = true;
+      this.isMessageShownOnBooking = true;
       try{
         await this.$store.dispatch("book", {
           office: { id: this.selectedOffice.id },

--- a/tests/unit/components/BookingForm.spec.js
+++ b/tests/unit/components/BookingForm.spec.js
@@ -109,4 +109,13 @@ describe("Component BookingForm.vue", () => {
 
         expect(wrapper.vm.isWarningShownOnBooking).toBe(true);
     })
+
+    it("should show a confirmation message on booking", async () => {
+
+        await flushPromises();
+
+        await wrapper.findComponent(BadContainedButton).props().click();
+
+        expect(wrapper.vm.isFeedbackShownOnBooking).toBe(true);
+    })
 });

--- a/tests/unit/components/BookingForm.spec.js
+++ b/tests/unit/components/BookingForm.spec.js
@@ -110,12 +110,12 @@ describe("Component BookingForm.vue", () => {
         expect(wrapper.vm.isWarningShownOnBooking).toBe(true);
     })
 
-    it("should show a confirmation message on booking", async () => {
+    it("should show a result message on booking", async () => {
 
         await flushPromises();
 
         await wrapper.findComponent(BadContainedButton).props().click();
 
-        expect(wrapper.vm.isFeedbackShownOnBooking).toBe(true);
+        expect(wrapper.vm.isMessageShownOnBooking).toBe(true);
     })
 });


### PR DESCRIPTION
- This PR fixes the orange span (below "Book a desk" button) is displayed by default : 

![image](https://user-images.githubusercontent.com/86605451/133268641-a360388e-00cf-479c-a694-2663c30fac73.png)

- There is no timeout on message so that in case there is an issue, the user can take a screenshot of the error and report to us
- I don't think we should display a warning when booking is successful but rather a success message (see below screenshot)

Final result : 

![image](https://user-images.githubusercontent.com/86605451/133268744-33c2a5f3-0940-4624-9be0-6179ead3562f.png)

